### PR TITLE
Fix simple typo in field autofill.

### DIFF
--- a/elevator.html
+++ b/elevator.html
@@ -48,7 +48,7 @@ destination:
 		<button type="button" onclick="addToDesc('The elevator door wont open/close. ')">Door Won't Open/Close</button>
 		<button type="button" onclick="addToDesc('The button is dirty. ')">Dirty</button>
 		<button type="button" onclick="addToDesc('The button or door is obstructed. ')">Obstructed</button>
-		<button type="button" onclick="addToDesc('I didn\'t feel safe using the elevatpor. ')">Feels Unsafe</button>
+		<button type="button" onclick="addToDesc('I didn\'t feel safe using the elevator. ')">Feels Unsafe</button>
 	</div>
 	<span>Please elaborate with more details in the box below</span>
 	<textarea id="description" name="description" required placeholder="Describe the issue..." rows="5"></textarea>


### PR DESCRIPTION
Fixed a simple typo in the autofill that populates when reporting that you feel unsafe using an elevator. This pull request has an associated issue at https://github.com/CampusPulse/report/issues/7