### PR TITLE
Discord Metadata for specific pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,5 @@ source "https://rubygems.org"
 # gem "rails"
 
 gem "jekyll", "~> 4.4"
+
+gem "jekyll-seo-tag", "~> 2.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,6 +41,8 @@ GEM
       webrick (~> 1.7)
     jekyll-sass-converter (3.0.0)
       sass-embedded (~> 1.54)
+    jekyll-seo-tag (2.8.0)
+      jekyll (>= 3.8, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     json (2.9.1)
@@ -75,6 +77,7 @@ PLATFORMS
 
 DEPENDENCIES
   jekyll (~> 4.4)
+  jekyll-seo-tag (~> 2.8)
 
 BUNDLED WITH
    2.4.19

--- a/_config.yml
+++ b/_config.yml
@@ -7,3 +7,6 @@ repository_url: "https://github.com/CampusPulse/report"
 baseurl: ""
 
 exclude: ["Gemfile", "Gemfile.lock"]
+
+plugins:
+  - jekyll-seo-tag

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -28,13 +28,8 @@
 		})();
 	</script>
 	<!-- End Matomo Code -->
+	
 	{% seo %}
-	<!-- Social Meta Tags -->
-	<!-- <meta property="og:title" content="{{ page.title  | default: 'CampusPulse Reporting System Page' }}"> -->
-	<!-- <meta property="og:description" content="{{ page.description | default: 'This is a page for the CampusPulse Reporting System' }}"> -->
-	<!-- Meta tag for image if applicable -->
-	<!-- <meta property="og:image" content="{{ page.image | absolute_url }}" /> -->
-	<!-- <meta property="og:url" content="{{ page.url | absolute_url }}" /> -->
 </head>
 
 <body>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -30,8 +30,8 @@
 	<!-- End Matomo Code -->
 
 	<!-- Social Meta Tags -->
-	<meta property="og:title" content="{{ page.title }}">
-	<meta property="og:description" content="{{ site.description }}">
+	<meta property="og:title" content="{{ page.title  | default: 'CampusPulse Reporting System Page' }}">
+	<meta property="og:description" content="{{ page.description | default: 'This is a page for the CampusPulse Reporting System' }}">
 	<!-- Meta tag for image if applicable -->
 	<!-- <meta property="og:image" content="{{ page.image | absolute_url }}" /> -->
 	<meta property="og:url" content="{{ page.url | absolute_url }}" />

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -30,11 +30,11 @@
 	<!-- End Matomo Code -->
 
 	<!-- Social Meta Tags -->
-	<meta property="og:title" content="{{ page.title  | default: 'CampusPulse Reporting System Page' }}">
-	<meta property="og:description" content="{{ page.description | default: 'This is a page for the CampusPulse Reporting System' }}">
+	<!-- <meta property="og:title" content="{{ page.title  | default: 'CampusPulse Reporting System Page' }}"> -->
+	<!-- <meta property="og:description" content="{{ page.description | default: 'This is a page for the CampusPulse Reporting System' }}"> -->
 	<!-- Meta tag for image if applicable -->
 	<!-- <meta property="og:image" content="{{ page.image | absolute_url }}" /> -->
-	<meta property="og:url" content="{{ page.url | absolute_url }}" />
+	<!-- <meta property="og:url" content="{{ page.url | absolute_url }}" /> -->
 </head>
 
 <body>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -28,6 +28,13 @@
 		})();
 	</script>
 	<!-- End Matomo Code -->
+
+	<!-- Social Meta Tags -->
+	<meta property="og:title" content="{{ page.title }}">
+	<meta property="og:description" content="{{ site.description }}">
+	<!-- Meta tag for image if applicable -->
+	<!-- <meta property="og:image" content="{{ page.image | absolute_url }}" /> -->
+	<meta property="og:url" content="{{ page.url | absolute_url }}" />
 </head>
 
 <body>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -28,7 +28,7 @@
 		})();
 	</script>
 	<!-- End Matomo Code -->
-
+	{% seo %}
 	<!-- Social Meta Tags -->
 	<!-- <meta property="og:title" content="{{ page.title  | default: 'CampusPulse Reporting System Page' }}"> -->
 	<!-- <meta property="og:description" content="{{ page.description | default: 'This is a page for the CampusPulse Reporting System' }}"> -->

--- a/bus.html
+++ b/bus.html
@@ -1,6 +1,7 @@
 ---
 layout: centercontent
 title: Report Bus Issues
+description: This is the form to report RIT Shuttle Bus that are late or broken. RIT Parking and Transportation Services (PATS) requests that reports be made if a bus is as little as 5-10 min.
 
 staticvalues:
   - name: what-area-does-this-pertain-to

--- a/button.html
+++ b/button.html
@@ -1,6 +1,7 @@
 ---
 layout: centercontent
 title: Report Broken Door Button
+description: This is the form to report broken door buttons around the RIT Campus.
 
 staticvalues:
   - name: phone

--- a/docs.html
+++ b/docs.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: CampusPulse Reporting System - Documentation
+description: Documentation for the CampusPulse Reporting System. This can help you navigate how to use this site to fill out ServiceNow Tickets for various issues.
 ---
 <h1>{{ page.title }}</h1>
 <p>Welcome to the CampusPulse Reporting System</p>

--- a/elevator.html
+++ b/elevator.html
@@ -1,7 +1,7 @@
 ---
 layout: centercontent
 title: Report Broken Elevator
-
+description: This is the form to report broken elevators around the RIT Campus.
 
 staticvalues:
   - name: phone

--- a/elevator.html
+++ b/elevator.html
@@ -21,6 +21,7 @@ destination:
 ---
 <!-- https://help.rit.edu/sp?id=sc_cat_item&sys_id=5deabdbb1bf641100ba4a7562a4bcb93 -->
 <p><strong>NOTE:</strong><br> If this is an emergency (i.e. you are stuck) please call public safety. <br> Their number is <a href="tel:585-475-3333">(585) 475-3333</a> </p>
+<p> If your elevator is on the <a href="https://access.campuspulse.app">CampusPulse Access Catalog</a> you can report from there with pre-filled fields when reporting a broken elevator.</p>
 
 {% include form_start.html destination=page.destination %}
 	<label for="name">Your Name</label>

--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: CampusPulse Reporting System
+description: The CampusPulse Reporting System Homepage where you can submit reports for broken elevator and broken door buttons.
 ---
 <h1>{{ page.title }}</h1>
 <p>Welcome to the CampusPulse Reporting System. This site aims to help guide you through the process of reporting issues to {{ site.servicenow_domain }} through forms that are easy to access</p>

--- a/index.html
+++ b/index.html
@@ -35,4 +35,4 @@ description: The CampusPulse Reporting System Homepage where you can submit repo
 </div>
 
 
-<p>Want to know how all this works? Check out our <a href="{{ "/docs.html" | relative_url }}">Documentation</a>!</p>
+<p>Want to know how all this works? Check out our <a href="{{ "/docs.html" | relative_url }}">Documentation</a>! Want to chat with us? Join our <a href="https://discord.access.campuspulse.app">Discord Server</a>!</p>

--- a/success.html
+++ b/success.html
@@ -1,6 +1,7 @@
 ---
 layout: centercontent
 title: Report Successful
+description: Your report has been submitted successfully!
 ---
 <p>Your report was successfully submitted</p>
 <p>Thank you for your submission!</p>

--- a/success.html
+++ b/success.html
@@ -3,8 +3,9 @@ layout: centercontent
 title: Report Successful
 description: Your report has been submitted successfully!
 ---
-<p>Your report was successfully submitted</p>
+<p>Your report was successfully submitted.</p>
 <p>Thank you for your submission!</p>
 
 <a href="/"><button>Report something else</button></a>
 <a href="https://campuspulse.app"><button>Back to CampusPulse</button></a>
+<a href="https://discord.access.campuspulse.app"><button>Join our Discord Server</button></a>

--- a/summary.html
+++ b/summary.html
@@ -1,6 +1,7 @@
 ---
 layout: centercontent
 title: Report Summary
+description: This is a summary of your filed report.
 ---
 <div class="summary">
 	<!-- Summary fields will be populated here -->


### PR DESCRIPTION
## Title: Closes #6  

## Description
As described in the issue I went ahead and added in meta tags for discord embedding. I created one for title, description, and URL. I confirmed that these 4 built correctly locally. I commented out the meta tag for image as I could not find an applicable image. Was not able to test embedding locally with localhost url.

## Checklist
- [x] Added in meta tags at _layouts/default.html
- [x] Created tags for Title, Description, and URL for default
- [x] Confirmed tags build correctly with correct data in _site locally (did **not** push _site of course)
- [x] Updated default metatags to include fallback title and description
- [x] Added in Proper descriptions for page below
- [x] bus.html
- [x] button.html
- [x] docs.html
- [x] elevator.html
- [x] index.html
- [x] succuss.html
- [x] summary.html
- [x] confirmed all changes build successfully
- [x] Changed to instead use the jekyll-seo-tag plugin
- [x] Added discord link in main page
- [x] Added discord button on success page
- [x] Added catalog link with short blurb to direct users to use if they wish to have pre-filled fields